### PR TITLE
Gd32vf103 rtthread nano

### DIFF
--- a/rt-thread/bsp/gd32vf103-blink/libraries/RISCV/env_Eclipse/GD32VF103x8.lds
+++ b/rt-thread/bsp/gd32vf103-blink/libraries/RISCV/env_Eclipse/GD32VF103x8.lds
@@ -43,6 +43,30 @@ SECTIONS
     *(.text.startup .text.startup.*)
     *(.text .text.*)
     *(.gnu.linkonce.t.*)
+   
+    /* section information for finsh shell */
+    . = ALIGN(4);
+    __fsymtab_start = .;
+    KEEP(*(FSymTab))
+    __fsymtab_end = .;
+    . = ALIGN(4);
+    __vsymtab_start = .;
+    KEEP(*(VSymTab))
+    __vsymtab_end = .;
+    . = ALIGN(4);
+    
+    /* section information for initial. */
+    . = ALIGN(4);
+    __rt_init_start = .;
+    KEEP(*(SORT(.rti_fn*)))
+    __rt_init_end = .;
+    . = ALIGN(4);
+
+    /* section information for modules */
+    . = ALIGN(4);
+    __rtmsymtab_start = .;
+    KEEP(*(RTMSymTab))
+    __rtmsymtab_end = .;
   } >flash AT>flash 
 
   .fini           :

--- a/rt-thread/bsp/gd32vf103-blink/libraries/RISCV/env_Eclipse/GD32VF103xB.lds
+++ b/rt-thread/bsp/gd32vf103-blink/libraries/RISCV/env_Eclipse/GD32VF103xB.lds
@@ -43,6 +43,30 @@ SECTIONS
     *(.text.startup .text.startup.*)
     *(.text .text.*)
     *(.gnu.linkonce.t.*)
+   
+    /* section information for finsh shell */
+    . = ALIGN(4);
+    __fsymtab_start = .;
+    KEEP(*(FSymTab))
+    __fsymtab_end = .;
+    . = ALIGN(4);
+    __vsymtab_start = .;
+    KEEP(*(VSymTab))
+    __vsymtab_end = .;
+    . = ALIGN(4);
+    
+    /* section information for initial. */
+    . = ALIGN(4);
+    __rt_init_start = .;
+    KEEP(*(SORT(.rti_fn*)))
+    __rt_init_end = .;
+    . = ALIGN(4);
+
+    /* section information for modules */
+    . = ALIGN(4);
+    __rtmsymtab_start = .;
+    KEEP(*(RTMSymTab))
+    __rtmsymtab_end = .;
   } >flash AT>flash 
 
   .fini           :


### PR DESCRIPTION
rtthread-nano的gd32vf103的bsp里的链接文件里没有__fsymtab_start相关内容，无法实现msh功能，我把rt-thread的gd32vf103的bsp里的cB里的链接文件中的相关 部分，复制到了这rtthread-nano下的bsp的c8,cb两个链接文件里。另，rt-thread的gd31vf103的bsp里，也只有cb链接文件有这部分。